### PR TITLE
Feat/59/api

### DIFF
--- a/requirements/backend/src/database/database.controller.ts
+++ b/requirements/backend/src/database/database.controller.ts
@@ -43,18 +43,27 @@ export class DatabaseController {
   async listAllUser() {
     return await this.databaseService.listAllUser();
   }
+  @ApiTags('database/User')
+  @ApiOperation({ summary: '유저 랭킹 목록 보기' })
+  @Get('show-user-list-rank')
+  async listUserRank() {
+    return await this.databaseService.listUserRank();
+  }
+
   @ApiTags('database/FriendList')
   @ApiOperation({ summary: '전체 친구 목록 보기' })
   @Get('show-friend-list-table')
   async listAllFriend() {
     return await this.databaseService.listAllFriend();
   }
+
   @ApiTags('database/BlockList')
   @ApiOperation({ summary: '전체 차단 목록 보기' })
   @Get('show-block-list-table')
   async listAllBlock() {
     return await this.databaseService.listAllBlock();
   }
+
   @ApiTags('database/Channel')
   @ApiOperation({ summary: '전체 채널 목록 보기' })
   @Get('show-channel-table')

--- a/requirements/backend/src/database/database.service.ts
+++ b/requirements/backend/src/database/database.service.ts
@@ -104,6 +104,10 @@ export class DatabaseService {
     return await this.dbDmLogsService.findDmLogsOfUser(user1, user2);
   }
 
+  async listUserRank() {
+    return await this.dbUserService.findUserRankList();
+  }
+
   async addUser(userDto: UserDto) {
     return await this.dbUserService.saveOne(userDto);
   }

--- a/requirements/backend/src/database/db.user/db.user.service.ts
+++ b/requirements/backend/src/database/db.user/db.user.service.ts
@@ -32,6 +32,26 @@ export class DbUserService {
     });
   }
 
+  async findUserRankList() {
+    return await this.userRepo.find({
+      select: {
+        uid: true,
+        displayName: true,
+        imgUri: true,
+        rating: true,
+        status: true,
+        mfaNeed: true,
+      },
+      order: {
+        rating: {
+          direction: 'desc',
+        },
+      },
+      skip: 0,
+      take: 10,
+    });
+  }
+
   async findOneWithLists(uid: number): Promise<UserEntity> {
     return await this.userRepo.findOne({
       relations: {

--- a/requirements/backend/src/main.ts
+++ b/requirements/backend/src/main.ts
@@ -1,6 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -21,7 +22,13 @@ async function bootstrap() {
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
-  app.enableCors();
+  app.enableCors({
+    origin: 'http://localhost:4242',
+    methods: ['GET', 'POST', 'PUT', 'DELETE'],
+    allowedHeaders: '*',
+    credentials: true,
+  });
+  app.useGlobalPipes(new ValidationPipe());
   await app.listen(4243);
 }
 bootstrap();

--- a/requirements/backend/src/users/decorator/jwt.payload.decorator.ts
+++ b/requirements/backend/src/users/decorator/jwt.payload.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const JwtPayload = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return (request as any).jwtPayload;
+  },
+);

--- a/requirements/backend/src/users/decorator/uid.decorator.ts
+++ b/requirements/backend/src/users/decorator/uid.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const Uid = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return (request as any).jwtPayload.id;
+  },
+);

--- a/requirements/backend/src/users/decorator/uid.decorator.ts
+++ b/requirements/backend/src/users/decorator/uid.decorator.ts
@@ -1,6 +1,6 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
-export const Uid = createParamDecorator(
+export const MyUid = createParamDecorator(
   (data: unknown, ctx: ExecutionContext) => {
     const request = ctx.switchToHttp().getRequest();
     return (request as any).jwtPayload.id;

--- a/requirements/backend/src/users/dto/uid.dto.ts
+++ b/requirements/backend/src/users/dto/uid.dto.ts
@@ -1,6 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IsInt } from 'class-validator';
 
 export class UidDto {
   @ApiProperty({ default: 0 })
+  @IsInt()
   uid: number;
 }

--- a/requirements/backend/src/users/dto/user.data.type.dto.ts
+++ b/requirements/backend/src/users/dto/user.data.type.dto.ts
@@ -3,5 +3,5 @@ export interface UserDataType {
   displayName: string;
   imgUri: string;
   rating: number;
-  status: number; // TODO 엔티티 컬럼 네임 수정.
+  status: number;
 }

--- a/requirements/backend/src/users/users.controller.ts
+++ b/requirements/backend/src/users/users.controller.ts
@@ -6,7 +6,6 @@ import {
   Body,
   Post,
   Delete,
-  Res,
   HttpException,
 } from '@nestjs/common';
 import {
@@ -16,16 +15,11 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { AuthGuard } from 'src/auth/auth.guard';
-import { Uid } from './decorator/uid.decorator';
+import { MyUid } from './decorator/uid.decorator';
 import { UidDto } from './dto/uid.dto';
 import { UsersService } from './users.service';
 import { UserDto } from 'src/database/dto/user.dto';
-import { Response } from 'express';
-import { JoinColumn } from 'typeorm';
-
-// TODO 데코레이터 적용하기.
-// TODO 파이프 적용하기.
-// TODO 유저 랭킹 api
+import { TokenPayloadDto } from 'src/login/token.payload.dto';
 
 @Controller('users')
 @UseGuards(AuthGuard)
@@ -40,7 +34,7 @@ export class UsersController {
   @ApiResponse({ status: 401, description: '쿠키 인증 실패' })
   @ApiResponse({ status: 404, description: '존재하지 않는 유저' })
   @Get('me')
-  async me(@Uid() uid) {
+  async me(@MyUid() uid: number) {
     return await this.usersService.me(uid);
   }
 
@@ -77,7 +71,7 @@ export class UsersController {
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '내 친구 목록 가져오기' })
   @Get('friend')
-  async friend(@Uid() uid) {
+  async friend(@MyUid() uid: number) {
     return await this.usersService.friend(uid);
   }
 
@@ -85,15 +79,23 @@ export class UsersController {
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '내 차단 목록 가져오기' })
   @Get('blocklist')
-  async blocklist(@Uid() uid) {
+  async blocklist(@MyUid() uid: number) {
     return await this.usersService.blocklist(uid);
+  }
+
+  @ApiTags('uesrs')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '랭킹 목록 가져오기' })
+  @Get('rank')
+  async rank() {
+    return await this.usersService.rank();
   }
 
   @ApiTags('uesrs')
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '친구 추가(팔로우)' })
   @Post('follow')
-  async follow(@Uid() uid, @Body() body: UidDto) {
+  async follow(@MyUid() uid: number, @Body() body: UidDto) {
     return await this.usersService.follow(uid, body.uid);
   }
 
@@ -101,7 +103,7 @@ export class UsersController {
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '친구 삭제(언팔로우)' })
   @Delete('follow')
-  async unfollow(@Uid() uid, @Body() body: UidDto) {
+  async unfollow(@MyUid() uid: number, @Body() body: UidDto) {
     return await this.usersService.unfollow(uid, body.uid);
   }
 
@@ -109,7 +111,7 @@ export class UsersController {
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '차단 하기' })
   @Post('block')
-  async block(@Uid() uid, @Body() body: UidDto) {
+  async block(@MyUid() uid: number, @Body() body: UidDto) {
     return await this.usersService.block(uid, body.uid);
   }
 
@@ -117,7 +119,7 @@ export class UsersController {
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '차단 해제' })
   @Delete('block')
-  async unblock(@Uid() uid, @Body() body: UidDto) {
+  async unblock(@MyUid() uid: number, @Body() body: UidDto) {
     return await this.usersService.unblock(uid, body.uid);
   }
 }

--- a/requirements/backend/src/users/users.controller.ts
+++ b/requirements/backend/src/users/users.controller.ts
@@ -16,7 +16,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { AuthGuard } from 'src/auth/auth.guard';
-import { TokenPayloadDto } from '../login/token.payload.dto';
+import { Uid } from './decorator/uid.decorator';
 import { UidDto } from './dto/uid.dto';
 import { UsersService } from './users.service';
 import { UserDto } from 'src/database/dto/user.dto';
@@ -40,9 +40,7 @@ export class UsersController {
   @ApiResponse({ status: 401, description: '쿠키 인증 실패' })
   @ApiResponse({ status: 404, description: '존재하지 않는 유저' })
   @Get('me')
-  async me(@Req() req) {
-    const payload: TokenPayloadDto = (req as any).jwtPayload;
-    const uid: number = payload.id;
+  async me(@Uid() uid) {
     return await this.usersService.me(uid);
   }
 
@@ -79,9 +77,7 @@ export class UsersController {
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '내 친구 목록 가져오기' })
   @Get('friend')
-  async friend(@Req() req) {
-    const payload: TokenPayloadDto = (req as any).jwtPayload;
-    const uid: number = payload.id;
+  async friend(@Uid() uid) {
     return await this.usersService.friend(uid);
   }
 
@@ -89,9 +85,7 @@ export class UsersController {
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '내 차단 목록 가져오기' })
   @Get('blocklist')
-  async blocklist(@Req() req) {
-    const payload: TokenPayloadDto = (req as any).jwtPayload;
-    const uid: number = payload.id;
+  async blocklist(@Uid() uid) {
     return await this.usersService.blocklist(uid);
   }
 
@@ -99,9 +93,7 @@ export class UsersController {
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '친구 추가(팔로우)' })
   @Post('follow')
-  async follow(@Req() req, @Body() body: UidDto) {
-    const payload: TokenPayloadDto = (req as any).jwtPayload;
-    const uid: number = payload.id;
+  async follow(@Uid() uid, @Body() body: UidDto) {
     return await this.usersService.follow(uid, body.uid);
   }
 
@@ -109,9 +101,7 @@ export class UsersController {
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '친구 삭제(언팔로우)' })
   @Delete('follow')
-  async unfollow(@Req() req, @Body() body: UidDto) {
-    const payload: TokenPayloadDto = (req as any).jwtPayload;
-    const uid: number = payload.id;
+  async unfollow(@Uid() uid, @Body() body: UidDto) {
     return await this.usersService.unfollow(uid, body.uid);
   }
 
@@ -119,9 +109,7 @@ export class UsersController {
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '차단 하기' })
   @Post('block')
-  async block(@Req() req, @Body() body: UidDto) {
-    const payload: TokenPayloadDto = (req as any).jwtPayload;
-    const uid: number = payload.id;
+  async block(@Uid() uid, @Body() body: UidDto) {
     return await this.usersService.block(uid, body.uid);
   }
 
@@ -129,9 +117,7 @@ export class UsersController {
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '차단 해제' })
   @Delete('block')
-  async unblock(@Req() req, @Body() body: UidDto) {
-    const payload: TokenPayloadDto = (req as any).jwtPayload;
-    const uid: number = payload.id;
+  async unblock(@Uid() uid, @Body() body: UidDto) {
     return await this.usersService.unblock(uid, body.uid);
   }
 }

--- a/requirements/backend/src/users/users.service.ts
+++ b/requirements/backend/src/users/users.service.ts
@@ -10,7 +10,6 @@ export class UsersService {
 
   async me(uid: number) {
     const user = await this.database.findOneUserProfile(uid);
-
     const profile: ProfileType = {
       ...user,
     };
@@ -41,6 +40,11 @@ export class UsersService {
       blocks.push(b.user);
     }
     return blocks;
+  }
+
+  async rank() {
+    const rankListInDb = await this.database.listUserRank();
+    return rankListInDb;
   }
 
   async follow(myUid: number, frinedUid: number) {

--- a/requirements/frontend/src/App.tsx
+++ b/requirements/frontend/src/App.tsx
@@ -1,11 +1,25 @@
+import * as React from 'react';
 import { RouterProvider } from 'react-router-dom';
-import { RecoilRoot } from 'recoil';
+import { RecoilRoot, useRecoilSnapshot } from 'recoil';
 import './App.css';
 import { Routes } from './Routes';
+
+function DebugObserver(): JSX.Element {
+  const snapshot = useRecoilSnapshot();
+  React.useEffect(() => {
+    console.debug('The following atoms were modified:');
+    for (const node of snapshot.getNodes_UNSTABLE({ isModified: true })) {
+      console.debug(node.key, snapshot.getLoadable(node));
+    }
+  }, [snapshot]);
+
+  return <></>;
+}
 
 function App() {
   return (
     <RecoilRoot>
+      {import.meta.env.DEV ? <DebugObserver /> : null}
       <RouterProvider router={Routes} />
     </RecoilRoot>
   );

--- a/requirements/frontend/src/atoms/authState.ts
+++ b/requirements/frontend/src/atoms/authState.ts
@@ -1,10 +1,11 @@
+import Cookies from 'js-cookie';
 import { atom, AtomEffect } from 'recoil';
 
-interface State {
+interface AuthStateType {
   token: string | null;
 }
 
-const localStorageEffect: AtomEffect<State> = ({ setSelf, onSet }) => {
+const localStorageEffect: AtomEffect<AuthStateType> = ({ setSelf, onSet }) => {
   const savedState = localStorage.getItem('auth');
   if (savedState !== null) {
     setSelf(JSON.parse(savedState));
@@ -13,13 +14,14 @@ const localStorageEffect: AtomEffect<State> = ({ setSelf, onSet }) => {
   onSet((newValue, _, isReset) => {
     if (isReset || newValue.token === null) {
       localStorage.removeItem('auth');
+      Cookies.remove('token');
     } else {
       localStorage.setItem('auth', JSON.stringify(newValue));
     }
   });
 };
 
-export const authState = atom<State>({
+export const authState = atom<AuthStateType>({
   key: 'auth',
   default: { token: null },
   effects: [localStorageEffect],

--- a/requirements/frontend/src/atoms/rankListState.ts
+++ b/requirements/frontend/src/atoms/rankListState.ts
@@ -20,7 +20,7 @@ const requestRankList = async (token: string): Promise<UserDataType[]> => {
     `${import.meta.env.VITE_BACKEND_EP}/users/rank`,
     {
       headers: {
-        Authorizatioin: `Bearer ${token}`,
+        Authorization: `Bearer ${token}`,
       },
     },
   );

--- a/requirements/frontend/src/mocks/handlers.ts
+++ b/requirements/frontend/src/mocks/handlers.ts
@@ -34,37 +34,37 @@ export const handlers = [
   //   },
   // ),
 
-  rest.get(`${import.meta.env.VITE_BACKEND_EP}/users/rank`, (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json([
-        {
-          uid: 2,
-          displayName: 'jeongble',
-          imgUri:
-            'https://ca.slack-edge.com/T039P7U66-U01GAGE28SE-4b0009a95b5a-512',
-          rating: 4096,
-          status: 'offline',
-        },
-        {
-          uid: 3,
-          displayName: 'yeju',
-          imgUri:
-            'https://ca.slack-edge.com/T039P7U66-U01GAGE28SE-4b0009a95b5a-512',
-          rating: 2048,
-          status: 'online',
-        },
-        {
-          uid: 99945,
-          displayName: 'jaham',
-          imgUri:
-            'https://ca.slack-edge.com/T039P7U66-U01GAGE28SE-4b0009a95b5a-512',
-          rating: 1024,
-          status: 'online',
-        },
-      ]),
-    );
-  }),
+  // rest.get(`${import.meta.env.VITE_BACKEND_EP}/users/rank`, (req, res, ctx) => {
+  //   return res(
+  //     ctx.status(200),
+  //     ctx.json([
+  //       {
+  //         uid: 2,
+  //         displayName: 'jeongble',
+  //         imgUri:
+  //           'https://ca.slack-edge.com/T039P7U66-U01GAGE28SE-4b0009a95b5a-512',
+  //         rating: 4096,
+  //         status: 'offline',
+  //       },
+  //       {
+  //         uid: 3,
+  //         displayName: 'yeju',
+  //         imgUri:
+  //           'https://ca.slack-edge.com/T039P7U66-U01GAGE28SE-4b0009a95b5a-512',
+  //         rating: 2048,
+  //         status: 'online',
+  //       },
+  //       {
+  //         uid: 99945,
+  //         displayName: 'jaham',
+  //         imgUri:
+  //           'https://ca.slack-edge.com/T039P7U66-U01GAGE28SE-4b0009a95b5a-512',
+  //         rating: 1024,
+  //         status: 'online',
+  //       },
+  //     ]),
+  //   );
+  // }),
 
   // rest.get(
   //   `${import.meta.env.VITE_BACKEND_EP}/channel/users`,

--- a/requirements/frontend/src/pages/login/Authenticate.tsx
+++ b/requirements/frontend/src/pages/login/Authenticate.tsx
@@ -1,6 +1,6 @@
+import * as React from 'react';
 import Cookies from 'js-cookie';
 import jwtDecode from 'jwt-decode';
-import * as React from 'react';
 import { useSetRecoilState } from 'recoil';
 import { authState } from '../../atoms/authState';
 import { LoginButton } from './LoginButton';
@@ -12,7 +12,7 @@ export interface JwtPayload {
 }
 
 export function Authenticate() {
-  const setIsAuthorized = useSetRecoilState(authState);
+  const setAuthState = useSetRecoilState(authState);
   const [token, setToken] = React.useState<string | null>(null);
 
   React.useEffect(() => {
@@ -23,9 +23,13 @@ export function Authenticate() {
     }
 
     const mfaNeed = jwtDecode<JwtPayload>(cookieToken).isRequiredTFA;
-    if (!mfaNeed) setIsAuthorized({ token: cookieToken });
+    if (!mfaNeed) {
+      setAuthState({ token: cookieToken });
+      return;
+    }
+
     setToken(cookieToken);
-  }, []);
+  }, [setAuthState]);
 
   if (token !== null) return <Otp />;
   return <LoginButton />;


### PR DESCRIPTION
<!--
[PART1]
작업 내용 요약 정리
- 작업을 진행한 이유
- 리뷰 순서 (코드리뷰할 추천 순서)
- 연결된 이슈
-->

## 📍 개요

1.  cors에 옵션을 추가했습니다.
 - http://fronted로 안되서 http://localhost:4242로 설정했습니다.

2. global validation pipe를 적용했습니다.
 - 앞으로 클라이언트에서 요청받는 부분의 Dto에 class-validator를 적용시켜주세요

3. MyUid, JwtPayload 데코레이터를 만들었습니다.
- 컨트롤러에서 내 uid, jwtPayload가 필요한 경우에 사용해주세요.   

- .
- close #59 
<!-- 만약 이슈도 PR과 동시에 종료시키려면 앞에 close를 명시[참고](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->

<!--
[PART2] // 필요할 때 주석을 지워서 사용하세요.
리뷰어를 위한 가이드제공 (선택사항)
- 일부 코드에 대한 자세한 설명
- 사용한 라이브러리와 이유
- 결과 이미지(frontend-컴포넌트 사진, backend-로그)
- 다음 작업 내용 공유
- ...
-->

<!-- ## 📖 리뷰 가이드

### 📝 추가 설명
```
코드 설명
```
- .

### 🎨 결과

- .

### ➡️ 다음 작업

- . -->
