### PR TITLE
match history 데이터베이스 api 구현

### DIFF
--- a/requirements/backend/src/app.module.ts
+++ b/requirements/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { ChannelEntity } from './database/entity/entity.channel';
 import { UserInChannelEntity } from './database/entity/entity.user.in.channel';
 import { DmLogEntity } from './database/entity/entity.dm.log';
 import { UsersModule } from './users/users.module';
+import { MatchHistoryEntity } from './database/entity/entity.matchhistory.list';
 
 dotenv.config({
   path: '/backend.env',
@@ -31,6 +32,7 @@ const dbOptions: TypeOrmModuleOptions = {
     ChannelEntity,
     UserInChannelEntity,
     DmLogEntity,
+    MatchHistoryEntity,
   ],
   synchronize: true,
 };

--- a/requirements/backend/src/database/database.controller.ts
+++ b/requirements/backend/src/database/database.controller.ts
@@ -196,7 +196,7 @@ export class DatabaseController {
   @ApiHeader({ name: 'uid' })
   @Get('list-all-match-history-of-user')
   async listAllMatchHistoryOfUser(@Headers() header) {
-    return await this.databaseService.listMatchHistoryOfUser(header.uid);
+    return await this.databaseService.listAllMatchHistoryOfUser(header.uid);
   }
 
   @ApiTags('database/MatchHistory')
@@ -204,26 +204,36 @@ export class DatabaseController {
   @ApiHeader({ name: 'uid' })
   @Get('list-all-match-history-of-user-with-user-info')
   async listAllMatchHistoryOfUserWithUserInfo(@Headers() header) {
-    return await this.databaseService.listMatchHistoryOfUserWithUserInfo(
+    return await this.databaseService.listAllMatchHistoryOfUserWithUserInfo(
       header.uid,
     );
   }
 
   @ApiTags('database/MatchHistory')
-  @ApiOperation({ summary: '유저의 전적 보기 (최근 5게임)' })
+  @ApiOperation({ summary: '유저의 전적 보기 (take, page)' })
   @ApiHeader({ name: 'uid' })
+  @ApiHeader({ name: 'take' })
+  @ApiHeader({ name: 'page' })
   @Get('list-user-match-history')
   async listMatchHistoryOfUser(@Headers() header) {
-    return await this.databaseService.listMatchHistoryOfUser(header.uid);
+    return await this.databaseService.listMatchHistoryOfUser(
+      header.uid,
+      header.take,
+      header.page,
+    );
   }
 
   @ApiTags('database/MatchHistory')
-  @ApiOperation({ summary: '유저의 전적 보기 (최근 5게임)' })
+  @ApiOperation({ summary: '유저의 전적 보기 (take, page)' })
   @ApiHeader({ name: 'uid' })
+  @ApiHeader({ name: 'take' })
+  @ApiHeader({ name: 'page' })
   @Get('list-user-match-history-with-user-info')
   async listMatchHistoryOfUserWithUserInfo(@Headers() header) {
     return await this.databaseService.listMatchHistoryOfUserWithUserInfo(
       header.uid,
+      header.take,
+      header.page,
     );
   }
 

--- a/requirements/backend/src/database/database.controller.ts
+++ b/requirements/backend/src/database/database.controller.ts
@@ -11,6 +11,7 @@ import { ApiBody, ApiHeader, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { DatabaseService } from './database.service';
 import { ChannelDto } from './dto/channel.dto';
 import { DmLogDto } from './dto/dm.log.dto';
+import { MatchHistoryDto } from './dto/match.history.dto';
 import { UserDto } from './dto/user.dto';
 import { UserInChannelDto } from './dto/user.in.channel.dto';
 
@@ -183,6 +184,49 @@ export class DatabaseController {
     );
   }
 
+  @ApiTags('database/MatchHistory')
+  @ApiOperation({ summary: '전체 전적 보기' })
+  @Get('show-match-history')
+  async listAllMatchHistory() {
+    return await this.databaseService.listAllMatchHistory();
+  }
+
+  @ApiTags('database/MatchHistory')
+  @ApiOperation({ summary: '유저의 전적 전부 보기' })
+  @ApiHeader({ name: 'uid' })
+  @Get('list-all-match-history-of-user')
+  async listAllMatchHistoryOfUser(@Headers() header) {
+    return await this.databaseService.listMatchHistoryOfUser(header.uid);
+  }
+
+  @ApiTags('database/MatchHistory')
+  @ApiOperation({ summary: '유저의 전적 전부 보기' })
+  @ApiHeader({ name: 'uid' })
+  @Get('list-all-match-history-of-user-with-user-info')
+  async listAllMatchHistoryOfUserWithUserInfo(@Headers() header) {
+    return await this.databaseService.listMatchHistoryOfUserWithUserInfo(
+      header.uid,
+    );
+  }
+
+  @ApiTags('database/MatchHistory')
+  @ApiOperation({ summary: '유저의 전적 보기 (최근 5게임)' })
+  @ApiHeader({ name: 'uid' })
+  @Get('list-user-match-history')
+  async listMatchHistoryOfUser(@Headers() header) {
+    return await this.databaseService.listMatchHistoryOfUser(header.uid);
+  }
+
+  @ApiTags('database/MatchHistory')
+  @ApiOperation({ summary: '유저의 전적 보기 (최근 5게임)' })
+  @ApiHeader({ name: 'uid' })
+  @Get('list-user-match-history-with-user-info')
+  async listMatchHistoryOfUserWithUserInfo(@Headers() header) {
+    return await this.databaseService.listMatchHistoryOfUserWithUserInfo(
+      header.uid,
+    );
+  }
+
   //NOTE - POST
   @ApiTags('database/User')
   @ApiOperation({ summary: '유저 추가하기' })
@@ -235,6 +279,13 @@ export class DatabaseController {
   @Post('add-dm')
   async addDmLog(@Body() body: DmLogDto) {
     return await this.databaseService.addDmLog(body);
+  }
+
+  @ApiTags('database/MatchHistory')
+  @ApiOperation({ summary: '전적 추가하기' })
+  @Post('add-match-history')
+  async addMatchHistory(@Body() body: MatchHistoryDto) {
+    return await this.databaseService.addMatchHistory(body);
   }
 
   //NOTE - PUT
@@ -485,5 +536,12 @@ export class DatabaseController {
       +header.uid,
       +header.chid,
     );
+  }
+
+  @ApiTags('database/MatchHistory')
+  @ApiOperation({ summary: '모든 전적 삭제' })
+  @Delete('delete-match-history')
+  async deleteMatchHistory() {
+    return await this.databaseService.deleteMatchHistory();
   }
 }

--- a/requirements/backend/src/database/database.module.ts
+++ b/requirements/backend/src/database/database.module.ts
@@ -7,6 +7,7 @@ import { DatabaseService } from './database.service';
 import { DbChannelModule } from './db.channel/db.channel.module';
 import { DbUserInChannelModule } from './db.user.in.channel/db.user.in.channel.module';
 import { DbDmLogModule } from './db.dm.log/db.dm.log.module';
+import { DbMatchHistoryModule } from './db.match.history/db.match.history.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { DbDmLogModule } from './db.dm.log/db.dm.log.module';
     DbChannelModule,
     DbUserInChannelModule,
     DbDmLogModule,
+    DbMatchHistoryModule,
   ],
   controllers: [DatabaseController],
   providers: [DatabaseService],

--- a/requirements/backend/src/database/database.service.ts
+++ b/requirements/backend/src/database/database.service.ts
@@ -3,10 +3,12 @@ import { DbBlockListService } from './db.block.list/db.block.list.service';
 import { DbChannelService } from './db.channel/db.channel.service';
 import { DbDmLogService } from './db.dm.log/db.dm.log.service';
 import { DbFriendListService } from './db.friend.list/db.friend.list.service';
+import { DbMatchHistoryService } from './db.match.history/db.match.history.service';
 import { DbUserInChannelService } from './db.user.in.channel/db.user.in.channel.service';
 import { DbUserService } from './db.user/db.user.service';
 import { ChannelDto } from './dto/channel.dto';
 import { DmLogDto } from './dto/dm.log.dto';
+import { MatchHistoryDto } from './dto/match.history.dto';
 import { UserDto } from './dto/user.dto';
 import { UserInChannelDto } from './dto/user.in.channel.dto';
 import { ChannelEntity } from './entity/entity.channel';
@@ -25,6 +27,7 @@ export class DatabaseService {
     private readonly dbDmLogsService: DbDmLogService,
     private readonly dbChannelService: DbChannelService,
     private readonly dbUserInChannelService: DbUserInChannelService,
+    private readonly dbMatchHistoryService: DbMatchHistoryService,
   ) {}
 
   async listAllUser() {
@@ -49,6 +52,10 @@ export class DatabaseService {
 
   async listAllDmLogs() {
     return await this.dbDmLogsService.findAll();
+  }
+
+  async listAllMatchHistory() {
+    return await this.dbMatchHistoryService.findAll();
   }
 
   async listUserFriend(uid: number) {
@@ -106,6 +113,21 @@ export class DatabaseService {
 
   async listUserRank() {
     return await this.dbUserService.findUserRankList();
+  }
+  async listMatchHistoryOfUser(uid: number) {
+    return await this.dbMatchHistoryService.findListOfUser(uid);
+  }
+
+  async listMatchHistoryOfUserWithUserInfo(uid: number) {
+    return await this.dbMatchHistoryService.findListOfUserWithInfo(uid);
+  }
+
+  async listAllMatchHistoryOfUser(uid: number) {
+    return await this.dbMatchHistoryService.findAllListOfUser(uid);
+  }
+
+  async listAllMatchHistoryOfUserWithUserInfo(uid: number) {
+    return await this.dbMatchHistoryService.findAllListOfUserWithInfo(uid);
   }
 
   async addUser(userDto: UserDto) {
@@ -191,6 +213,24 @@ export class DatabaseService {
     if (fromUser.uid === toUser.uid)
       throw new HttpException('잘못된 요청입니다.', HttpStatus.FORBIDDEN);
     this.dbDmLogsService.saveOne(dmLog, fromUser, toUser);
+  }
+
+  async addMatchHistory(matchHistory: MatchHistoryDto) {
+    // 자기 자신과 경기 할 수 없음
+    if (matchHistory.winnerUid === matchHistory.loserUid)
+      throw new HttpException('invalid game history', HttpStatus.FORBIDDEN);
+
+    const winner: UserEntity = await this.dbUserService.findOne(
+      matchHistory.winnerUid,
+    );
+    const loser: UserEntity = await this.dbUserService.findOne(
+      matchHistory.loserUid,
+    );
+    return await this.dbMatchHistoryService.saveOne(
+      matchHistory,
+      winner,
+      loser,
+    );
   }
 
   async findOneUser(uid: number) {
@@ -354,6 +394,10 @@ export class DatabaseService {
     console.log(typeof uid);
     if (channel.chOwnerId === uid) this.deleteChannel(uid, chid);
     return await this.dbUserInChannelService.deleteOne(uid, chid);
+  }
+
+  async deleteMatchHistory() {
+    return await this.dbMatchHistoryService.deleteAll();
   }
 
   private async checkPermissionInChannel(

--- a/requirements/backend/src/database/database.service.ts
+++ b/requirements/backend/src/database/database.service.ts
@@ -114,12 +114,31 @@ export class DatabaseService {
   async listUserRank() {
     return await this.dbUserService.findUserRankList();
   }
-  async listMatchHistoryOfUser(uid: number) {
-    return await this.dbMatchHistoryService.findListOfUser(uid);
+
+  async listMatchHistoryOfUser(uid: number, take: number, page: number) {
+    if (page < 1)
+      throw new HttpException(
+        'page must not be 0 or negative',
+        HttpStatus.BAD_REQUEST,
+      );
+    return await this.dbMatchHistoryService.findListOfUser(uid, take, page);
   }
 
-  async listMatchHistoryOfUserWithUserInfo(uid: number) {
-    return await this.dbMatchHistoryService.findListOfUserWithInfo(uid);
+  async listMatchHistoryOfUserWithUserInfo(
+    uid: number,
+    take: number,
+    page: number,
+  ) {
+    if (page < 1)
+      throw new HttpException(
+        'page must not be 0 or negative',
+        HttpStatus.BAD_REQUEST,
+      );
+    return await this.dbMatchHistoryService.findListOfUserWithInfo(
+      uid,
+      take,
+      page,
+    );
   }
 
   async listAllMatchHistoryOfUser(uid: number) {

--- a/requirements/backend/src/database/db.match.history/db.match.history.module.ts
+++ b/requirements/backend/src/database/db.match.history/db.match.history.module.ts
@@ -1,11 +1,11 @@
-// import { Module } from '@nestjs/common';
-// import { TypeOrmModule } from '@nestjs/typeorm';
-// import { MatchHistoryEntity } from '../entity/entity.matchhistory.list';
-// import { DbMatchHistoryService } from './db.match.history.service';
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DbMatchHistoryService } from './db.match.history.service';
+import { MatchHistoryEntity } from '../entity/entity.matchhistory.list';
 
-// @Module({
-//     imports: [TypeOrmModule.forFeature([MatchHistoryEntity])],
-//     providers: [DbMatchHistoryService],
-//     exports: [DbMatchHistoryService],
-// })
-// export class DbMatchHistoryModule {}
+@Module({
+  imports: [TypeOrmModule.forFeature([MatchHistoryEntity])],
+  providers: [DbMatchHistoryService],
+  exports: [DbMatchHistoryService],
+})
+export class DbMatchHistoryModule {}

--- a/requirements/backend/src/database/db.match.history/db.match.history.service.ts
+++ b/requirements/backend/src/database/db.match.history/db.match.history.service.ts
@@ -1,26 +1,125 @@
-// import { Injectable } from '@nestjs/common';
-// import { InjectRepository } from '@nestjs/typeorm';
-// import { Repository } from 'typeorm';
-// import { RelationListDto } from '../dto/relation.list.dto';
-// import { MatchHistoryEntity } from '../entity/entity.matchhistory.list';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { MatchHistoryDto } from '../dto/match.history.dto';
+import { MatchHistoryEntity } from '../entity/entity.matchhistory.list';
+import { UserEntity } from '../entity/entity.user';
 
-// @Injectable()
-// export class DbMatchHistoryService {
-//   constructor(
-//     @InjectRepository(MatchHistoryEntity)
-//     private matchHistoryRepo: Repository<MatchHistoryEntity>,
-//   ) {}
+@Injectable()
+export class DbMatchHistoryService {
+  constructor(
+    @InjectRepository(MatchHistoryEntity)
+    private matchHistoryRepo: Repository<MatchHistoryEntity>,
+  ) {}
 
-//   async findAll() {
-//     return await this.matchHistoryRepo.find();
-//   }
+  async findAll() {
+    return await this.matchHistoryRepo.find();
+  }
 
-//   async saveOne(
-//     matchHistory: RelationListDto, //p1, p2를 RelationListDto를 쓰기위해 f, t
-//   ): Promise<void> {
-//     const his = new MatchHistoryEntity();
-//     his.player1uid = matchHistory.fromUid;
-//     his.player2uid = matchHistory.toUid;
-//     await this.matchHistoryRepo.save(his);
-//   }
-// }
+  async findAllListOfUser(uid: number) {
+    return await this.matchHistoryRepo.find({
+      select: {
+        index: true,
+        winnerUid: true,
+        loserUid: true,
+      },
+      where: [{ winnerUid: uid }, { loserUid: uid }],
+      order: {
+        index: 'desc',
+      },
+    });
+  }
+
+  async findListOfUser(uid: number) {
+    return await this.matchHistoryRepo.find({
+      select: {
+        index: true,
+        winnerUid: true,
+        loserUid: true,
+      },
+      where: [{ winnerUid: uid }, { loserUid: uid }],
+      order: {
+        index: 'desc',
+      },
+      take: 5,
+    });
+  }
+
+  async findAllListOfUserWithInfo(uid: number) {
+    return await this.matchHistoryRepo.find({
+      select: {
+        index: true,
+        winner: {
+          uid: true,
+          displayName: true,
+          imgUri: true,
+          status: true,
+        },
+        loser: {
+          uid: true,
+          displayName: true,
+          imgUri: true,
+          status: true,
+        },
+      },
+      relations: {
+        winner: true,
+        loser: true,
+      },
+      where: [{ winnerUid: uid }, { loserUid: uid }],
+      order: {
+        index: 'desc',
+      },
+    });
+  }
+
+  async findListOfUserWithInfo(uid: number) {
+    return await this.matchHistoryRepo.find({
+      select: {
+        index: true,
+        winner: {
+          uid: true,
+          displayName: true,
+          imgUri: true,
+          status: true,
+        },
+        loser: {
+          uid: true,
+          displayName: true,
+          imgUri: true,
+          status: true,
+        },
+      },
+      relations: {
+        winner: true,
+        loser: true,
+      },
+      where: [{ winnerUid: uid }, { loserUid: uid }],
+      order: {
+        index: 'desc',
+      },
+      take: 5,
+    });
+  }
+
+  async saveOne(
+    matchHistory: MatchHistoryDto | MatchHistoryEntity,
+    winner: UserEntity,
+    loser: UserEntity,
+  ) {
+    const history = this.matchHistoryRepo.create({
+      ...matchHistory,
+      winner,
+      loser,
+    });
+    try {
+      await this.matchHistoryRepo.save(history);
+    } catch (err) {
+      throw new HttpException('invalid game history', HttpStatus.FORBIDDEN);
+    }
+  }
+
+  async deleteAll() {
+    return await this.matchHistoryRepo.clear();
+  }
+}

--- a/requirements/backend/src/database/db.match.history/db.match.history.service.ts
+++ b/requirements/backend/src/database/db.match.history/db.match.history.service.ts
@@ -53,10 +53,12 @@ export class DbMatchHistoryService {
       select: {
         index: true,
         winner: {
+          uid: true,
           displayName: true,
           imgUri: true,
         },
         loser: {
+          uid: true,
           displayName: true,
           imgUri: true,
         },
@@ -78,10 +80,12 @@ export class DbMatchHistoryService {
       select: {
         index: true,
         winner: {
+          uid: true,
           displayName: true,
           imgUri: true,
         },
         loser: {
+          uid: true,
           displayName: true,
           imgUri: true,
         },

--- a/requirements/backend/src/database/db.match.history/db.match.history.service.ts
+++ b/requirements/backend/src/database/db.match.history/db.match.history.service.ts
@@ -22,6 +22,7 @@ export class DbMatchHistoryService {
         index: true,
         winnerUid: true,
         loserUid: true,
+        isRank: true,
       },
       where: [{ winnerUid: uid }, { loserUid: uid }],
       order: {
@@ -30,18 +31,20 @@ export class DbMatchHistoryService {
     });
   }
 
-  async findListOfUser(uid: number) {
+  async findListOfUser(uid: number, take: number, page: number) {
     return await this.matchHistoryRepo.find({
       select: {
         index: true,
         winnerUid: true,
         loserUid: true,
+        isRank: true,
       },
       where: [{ winnerUid: uid }, { loserUid: uid }],
       order: {
         index: 'desc',
       },
-      take: 5,
+      skip: (page - 1) * take, // index 1부터 시작
+      take: take,
     });
   }
 
@@ -50,17 +53,14 @@ export class DbMatchHistoryService {
       select: {
         index: true,
         winner: {
-          uid: true,
           displayName: true,
           imgUri: true,
-          status: true,
         },
         loser: {
-          uid: true,
           displayName: true,
           imgUri: true,
-          status: true,
         },
+        isRank: true,
       },
       relations: {
         winner: true,
@@ -73,22 +73,19 @@ export class DbMatchHistoryService {
     });
   }
 
-  async findListOfUserWithInfo(uid: number) {
+  async findListOfUserWithInfo(uid: number, take: number, page: number) {
     return await this.matchHistoryRepo.find({
       select: {
         index: true,
         winner: {
-          uid: true,
           displayName: true,
           imgUri: true,
-          status: true,
         },
         loser: {
-          uid: true,
           displayName: true,
           imgUri: true,
-          status: true,
         },
+        isRank: true,
       },
       relations: {
         winner: true,
@@ -98,7 +95,8 @@ export class DbMatchHistoryService {
       order: {
         index: 'desc',
       },
-      take: 5,
+      skip: (page - 1) * take,
+      take: take,
     });
   }
 

--- a/requirements/backend/src/database/dto/match.history.dto.ts
+++ b/requirements/backend/src/database/dto/match.history.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MatchHistoryDto {
+  @ApiProperty()
+  winnerUid: number;
+  @ApiProperty()
+  loserUid: number;
+  @ApiProperty()
+  isRank: boolean;
+}

--- a/requirements/backend/src/database/entity/entity.matchhistory.list.ts
+++ b/requirements/backend/src/database/entity/entity.matchhistory.list.ts
@@ -1,20 +1,37 @@
-// import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
-// import { UserEntity } from './entity.user';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { UserEntity } from './entity.user';
 
-// @Entity()
-// export class MatchHistoryEntity {
-//   @PrimaryGeneratedColumn()
-//   index: number;
+@Entity()
+export class MatchHistoryEntity {
+  @PrimaryGeneratedColumn()
+  index: number;
 
-//   @Column({ type: 'integer' })
-//   player1uid: number;
+  @Column({ type: 'boolean' })
+  isRank: boolean;
 
-//   @Column({ type: 'integer' })
-//   player2uid: number;
+  @Column({ type: 'integer' })
+  winnerUid: number;
 
-//   @Column({ type: 'boolean' })
-//   isPlayer1Win: boolean;
+  @Column({ type: 'integer' })
+  loserUid: number;
 
-//   @ManyToOne(() => UserEntity, (user) => user.matchHistory)
-//   user: UserEntity;
-// }
+  @ManyToOne(() => UserEntity, (winner) => winner.winnerList)
+  @JoinColumn({
+    name: 'winnerUid',
+    referencedColumnName: 'uid',
+  })
+  winner: UserEntity;
+
+  @ManyToOne(() => UserEntity, (loser) => loser.loserList)
+  @JoinColumn({
+    name: 'loserUid',
+    referencedColumnName: 'uid',
+  })
+  loser: UserEntity;
+}

--- a/requirements/backend/src/database/entity/entity.user.ts
+++ b/requirements/backend/src/database/entity/entity.user.ts
@@ -3,7 +3,7 @@ import { FriendListEntity } from './entity.friend.list';
 import { BlockListEntity } from './entity.block.list';
 import { UserInChannelEntity } from './entity.user.in.channel';
 // import { DmLogEntity } from './entity.dm.log';
-// import { MatchHistoryEntity } from './entity.matchhistory.list';
+import { MatchHistoryEntity } from './entity.matchhistory.list';
 
 export enum UserStatus {
   OFFLINE,
@@ -46,6 +46,10 @@ export class UserEntity {
 
   // @OneToMany(() => DmLogEntity, (dmList) => dmList.fromUser)
   // dmList: DmLogEntity[];
-  // @OneToMany(() => MatchHistoryEntity, (matchHistory) => matchHistory.user)
-  // matchHistory: MatchHistoryEntity[];
+
+  @OneToMany(() => MatchHistoryEntity, (winnerList) => winnerList.winner)
+  winnerList: MatchHistoryEntity[];
+
+  @OneToMany(() => MatchHistoryEntity, (loserList) => loserList.loser)
+  loserList: MatchHistoryEntity[];
 }


### PR DESCRIPTION
<!--
[PART1]
작업 내용 요약 정리
- 작업을 진행한 이유
- 리뷰 순서 (코드리뷰할 추천 순서)
- 연결된 이슈
-->

## 📍 개요
match history 데이터베이스 api 기본 구현
- 전체 보기, 유저의 전적 전체/일부 보기, 추가, 모든 전적 삭제
- 유저의 전적 페이지단위로 가져오도록 설정
- close #65 
<!-- 만약 이슈도 PR과 동시에 종료시키려면 앞에 close를 명시[참고](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->

<!--
[PART2] // 필요할 때 주석을 지워서 사용하세요.
리뷰어를 위한 가이드제공 (선택사항)
- 일부 코드에 대한 자세한 설명
- 사용한 라이브러리와 이유
- 결과 이미지(frontend-컴포넌트 사진, backend-로그)
- 다음 작업 내용 공유
- ...
-->

## 📖 리뷰 가이드

### 🎨 결과

- index는 전체 게임에서의 순서 (자동 인덱스) -> 별 의미 없음
- 이기고 지고 상관 없이 해당 유저의 게임 정보를 불러와 최신순으로 정렬

<img width="425" alt="image" src="https://user-images.githubusercontent.com/76509884/195256849-ed3c4158-3f3c-4b3a-ab5d-eb9b130a25f0.png">



