### PR TITLE
Feat/94/image from intra

### DIFF
--- a/requirements/.dev/entrypoint.database.sql
+++ b/requirements/.dev/entrypoint.database.sql
@@ -418,19 +418,20 @@ COPY public.match_history_entity (index, "isRank", "winnerUid", "loserUid") FROM
 --
 
 COPY public.user_entity (uid, "displayName", "imgUri", rating, "mfaNeed", "qrSecret", status) FROM stdin;
-81730	yeju	http://backend/users/img/default_img	42	f	KAHBK63XHN6SYMJV	0
-99857	mypark	http://backend/users/img/default_img	42	f	PZSQCFRPDERRSMIZ	0
-85355	hyojekim	http://backend/users/img/default_img	42	t	OQ2XQJSDKMFS2A2B	0
-0	dummy0	http://backend/users/img/default_img	0	f	string	0
-1	dummy1	http://backend/users/img/default_img	2000	f	string	0
-2	dummy2	http://backend/users/img/default_img	200	f	string	0
-3	dummy3	http://backend/users/img/default_img	20000	f	string	0
-4	dummy4	http://backend/users/img/default_img	200	f	string	0
-5	dummy5	http://backend/users/img/default_img	4242	f	string	0
-99947	jaham	http://backend/users/img/default_img	42	f	O4TX43QVPVNFQOSP	0
-6	dummy6	http://backend/users/img/default_img	2020	f	string	0
-99909	chanhpar	http://backend/users/img/default_img	42	f	LZHV6YQHNVTVA4RW	0
-112230	9ey7a3gdu	http://backend/users/img/default_img	42	f	M5NA6HJHAMXQKQIH	0
+81730	yeju	https://cdn.intra.42.fr/users/small_yeju.jpg	42	f	KAHBK63XHN6SYMJV	0
+99857	mypark	https://cdn.intra.42.fr/users/small_mypark.jpg	42	f	PZSQCFRPDERRSMIZ	0
+85355	hyojekim	https://cdn.intra.42.fr/users/small_hyojekim.jpg	42	t	OQ2XQJSDKMFS2A2B	0
+0	dummy0	https://cdn.intra.42.fr/users/small_sujpark.jpg	0	f	string	0
+1	dummy1	https://cdn.intra.42.fr/users/small_sujpark.jpg	2000	f	string	0
+2	dummy2	https://cdn.intra.42.fr/users/small_sujpark.jpg	200	f	string	0
+3	dummy3	https://cdn.intra.42.fr/users/small_sujpark.jpg	20000	f	string	0
+4	dummy4	https://cdn.intra.42.fr/users/small_sujpark.jpg	200	f	string	0
+5	dummy5	https://cdn.intra.42.fr/users/small_sujpark.jpg	4242	f	string	0
+99947	jaham	https://cdn.intra.42.fr/users/small_jaham.jpg	42	f	O4TX43QVPVNFQOSP	0
+6	dummy6	https://cdn.intra.42.fr/users/small_mypark.jpg	2020	f	string	0
+99909	chanhpar	https://cdn.intra.42.fr/users/small_chanhpar.jpg	42	f	LZHV6YQHNVTVA4RW	0
+112230	9ey7a3gdu	https://cdn.intra.42.fr/users/small_jaham.jpg	42	f	M5NA6HJHAMXQKQIH	0
+99778	qm3tc7kxp	http://localhost:4243/users/img/99778	42	f	KVFGW6TMD5UHGMJ5	0
 \.
 
 

--- a/requirements/backend/src/database/db.user/db.user.service.ts
+++ b/requirements/backend/src/database/db.user/db.user.service.ts
@@ -73,7 +73,7 @@ export class DbUserService {
   async saveOne(userDto: UserDto | UserEntity): Promise<void> {
     const user = this.userRepo.create({
       ...userDto,
-      imgUri: `http://backend/users/img/${userDto.uid}`,
+      imgUri: `http://localhost:4243/users/img/${userDto.uid}`,
       status: UserStatus.OFFLINE,
     });
     try {

--- a/requirements/backend/src/database/dto/user.dto.ts
+++ b/requirements/backend/src/database/dto/user.dto.ts
@@ -5,7 +5,7 @@ export class UserDto {
   uid: number;
   @ApiProperty({ example: 'jaham' })
   displayName: string;
-  @ApiProperty({ example: 'http://backend/users/img/default_img' })
+  @ApiProperty({ example: 'http://localhost:4243/users/img/uid' })
   imgUri: string;
   @ApiProperty()
   rating: number;

--- a/requirements/backend/src/login/login.service.ts
+++ b/requirements/backend/src/login/login.service.ts
@@ -57,7 +57,10 @@ export class LoginService {
     );
 
     fs.mkdirSync('img/', { recursive: true });
-    fs.writeFileSync(`img/${userInfo.data.id}.png`, imgData.data);
+    fs.writeFileSync(
+      `img/${userInfo.data.id}`,
+      `data:image/png;base64,${imgData.data}`,
+    );
 
     return userInfo.data.id;
   }
@@ -107,7 +110,7 @@ export class LoginService {
       const newUser: UserDto = {
         uid: uid,
         displayName: Math.random().toString(36).substring(2, 11),
-        imgUri: `http://backend/users/img/${uid}`,
+        imgUri: `http://localhost:4243/users/img/${uid}`,
         rating: 42,
         mfaNeed: false,
         qrSecret: authenticator.generateSecret(),


### PR DESCRIPTION
<!--
[PART1]
작업 내용 요약 정리
- 작업을 진행한 이유
- 리뷰 순서 (코드리뷰할 추천 순서)
- 연결된 이슈
-->

## 📍 개요

1. 디비에 기본 이미지 uri를 인트라 cdn에서 가져오도록 쿼리 수정했습니다.
2. 회원가입할 때, 인트라 cdn에서 이미지를 다운 받아서 백엔드 서버의 backend/img/uid로 저장되는 기능을 추가하였습니다.


- .
- #94 
<!-- 만약 이슈도 PR과 동시에 종료시키려면 앞에 close를 명시[참고](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->

<!--
[PART2] // 필요할 때 주석을 지워서 사용하세요.
리뷰어를 위한 가이드제공 (선택사항)
- 일부 코드에 대한 자세한 설명
- 사용한 라이브러리와 이유
- 결과 이미지(frontend-컴포넌트 사진, backend-로그)
- 다음 작업 내용 공유
- ...
-->

<!-- ## 📖 리뷰 가이드

### 📝 추가 설명
```
코드 설명
```
- .

### 🎨 결과

- .

### ➡️ 다음 작업

- . -->
