### PR TITLE
Feat/157/game result

### DIFF
--- a/requirements/backend/src/app.gateway.ts
+++ b/requirements/backend/src/app.gateway.ts
@@ -28,9 +28,9 @@ export class AppGateway {
     await this.validateUser(client);
     client.join(`dm${client.data.uid}`);
     // FIXME 테스트용.
-    // if (client.data.uid === 85355) {
-    //   client.join(`channel20`);
-    //   console.log(`socketInit: ${client.data.uid} join channel20`);
+    // if (client.data.uid === 99857) {
+    //   client.join(`channel7`);
+    //   console.log(`socketInit: ${client.data.uid} join channel7`);
     // }
     console.log(`socketInit: ${client.data.uid} join dm${client.data.uid}`);
     await this.dmGateway.updateUser(client.data.uid);

--- a/requirements/backend/src/app.module.ts
+++ b/requirements/backend/src/app.module.ts
@@ -19,6 +19,7 @@ import { ChatModule } from './chat/chat.module';
 import { DmModule } from './dm/dm.module';
 import { AppGateway } from './app.gateway';
 import { LoggerMiddleware } from './logger.middleware';
+import { GameModule } from './game/game.module';
 
 dotenv.config({
   path: '/backend.env',
@@ -54,6 +55,7 @@ const dbOptions: TypeOrmModuleOptions = {
     TypeOrmModule.forRoot(dbOptions),
     DatabaseModule,
     DmModule,
+    GameModule,
   ],
   controllers: [AppController],
   providers: [AppService, AppGateway],

--- a/requirements/backend/src/game/game.controller.ts
+++ b/requirements/backend/src/game/game.controller.ts
@@ -1,0 +1,16 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { MatchHistoryDto } from 'src/database/dto/match.history.dto';
+import { GameResultService } from './game.result.service';
+
+@Controller('game')
+export class GameController {
+  constructor(private readonly gameResultService: GameResultService) {}
+
+  @ApiTags('game')
+  @ApiOperation({ summary: '게임 결과 계산 테스트' })
+  @Post('game-result')
+  async calcGameResult(@Body() body: MatchHistoryDto) {
+    this.gameResultService.saveResult(body);
+  }
+}

--- a/requirements/backend/src/game/game.module.ts
+++ b/requirements/backend/src/game/game.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from 'src/database/database.module';
+import { GameResultService } from './game.result.service';
+import { GameController } from './game.controller';
+
+@Module({
+  imports: [DatabaseModule],
+  providers: [GameResultService],
+  controllers: [GameController],
+})
+export class GameModule {}

--- a/requirements/backend/src/game/game.module.ts
+++ b/requirements/backend/src/game/game.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { DatabaseModule } from 'src/database/database.module';
 import { GameResultService } from './game.result.service';
 import { GameController } from './game.controller';
+import { DmModule } from 'src/dm/dm.module';
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, DmModule],
   providers: [GameResultService],
   controllers: [GameController],
 })

--- a/requirements/backend/src/game/game.result.dto.ts
+++ b/requirements/backend/src/game/game.result.dto.ts
@@ -1,0 +1,5 @@
+export class GameResultDto {
+  winnerUid: number;
+  losterUid: number;
+  isRank: boolean;
+}

--- a/requirements/backend/src/game/game.result.dto.ts
+++ b/requirements/backend/src/game/game.result.dto.ts
@@ -1,5 +1,0 @@
-export class GameResultDto {
-  winnerUid: number;
-  losterUid: number;
-  isRank: boolean;
-}

--- a/requirements/backend/src/game/game.result.service.ts
+++ b/requirements/backend/src/game/game.result.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { DatabaseService } from 'src/database/database.service';
+import { MatchHistoryDto } from 'src/database/dto/match.history.dto';
+
+const K = 10; // Elo 가중치
+
+@Injectable()
+export class GameResultService {
+  constructor(private readonly database: DatabaseService) {}
+  async saveResult(gameResult: MatchHistoryDto) {
+    await this.database.addMatchHistory(gameResult); // TODO transaction
+    if (gameResult.isRank) {
+      await this.updateRating(gameResult);
+    }
+  }
+
+  async updateRating(gameResult: MatchHistoryDto) {
+    const winner = await this.database.findOneUser(gameResult.winnerUid);
+    const loser = await this.database.findOneUser(gameResult.loserUid);
+
+    winner.rating = this.calcRating(winner.rating, loser.rating, true);
+    loser.rating = this.calcRating(loser.rating, winner.rating, false);
+
+    console.log(
+      `game.result.service: updateRating: winner.rating ${winner.rating}`,
+    );
+    console.log(
+      `game.result.service: updateRating: loser.rating ${loser.rating}`,
+    );
+
+    await this.database.updateUserRating(winner.uid, winner.rating); // TODO transaction depth?
+    await this.database.updateUserRating(loser.uid, loser.rating);
+  }
+
+  calcRating(player1: number, player2: number, isWin: boolean): number {
+    const we = 1 / (Math.pow(10, (player2 - player1) / 400) + 1);
+    const w = isWin ? 1 : 0;
+    return Math.floor(player1 + K * (w - we));
+  }
+}

--- a/requirements/backend/src/game/game.result.service.ts
+++ b/requirements/backend/src/game/game.result.service.ts
@@ -1,17 +1,24 @@
 import { Injectable } from '@nestjs/common';
 import { DatabaseService } from 'src/database/database.service';
 import { MatchHistoryDto } from 'src/database/dto/match.history.dto';
+import { DmGateway } from 'src/dm/dm.gateway';
 
 const K = 10; // Elo 가중치
 
 @Injectable()
 export class GameResultService {
-  constructor(private readonly database: DatabaseService) {}
+  constructor(
+    private readonly database: DatabaseService,
+    private readonly dmGateway: DmGateway,
+  ) {}
+
   async saveResult(gameResult: MatchHistoryDto) {
     await this.database.addMatchHistory(gameResult); // TODO transaction
     if (gameResult.isRank) {
       await this.updateRating(gameResult);
     }
+    this.dmGateway.updateUser(gameResult.winnerUid);
+    this.dmGateway.updateUser(gameResult.loserUid);
   }
 
   async updateRating(gameResult: MatchHistoryDto) {

--- a/requirements/backend/src/main.ts
+++ b/requirements/backend/src/main.ts
@@ -13,6 +13,7 @@ import { UsersModule } from './users/users.module';
 import { DmModule } from './dm/dm.module';
 import { AuthModule } from './auth/auth.module';
 import { LoginModule } from './login/login.module';
+import { GameModule } from './game/game.module';
 
 const configDb = new DocumentBuilder()
   .setTitle('db controller')
@@ -21,7 +22,7 @@ const configDb = new DocumentBuilder()
   .build();
 
 const optionDb: SwaggerDocumentOptions = {
-  include: [DatabaseModule],
+  include: [DatabaseModule, GameModule],
 };
 
 const configApi = new DocumentBuilder()


### PR DESCRIPTION
<!--
[PART1]
작업 내용 요약 정리
- 작업을 진행한 이유
- 리뷰 순서 (코드리뷰할 추천 순서)
- 연결된 이슈
-->

## 📍 개요

- #157 
게임이 끝나면 결과를 받아서 매치 히스토리, 유저 레이팅 업데이트하여 저장하는 로직을 구현하였습니다.
나의 프로필을 볼 수 있는 내 팔로워들, 내가 들어가 있는 채널에 나의 프로필 정보를 보내 업데이트 할 수 있도록 하였습니다.
<!-- 만약 이슈도 PR과 동시에 종료시키려면 앞에 close를 명시[참고](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->

<!--
[PART2] // 필요할 때 주석을 지워서 사용하세요.
리뷰어를 위한 가이드제공 (선택사항)
- 일부 코드에 대한 자세한 설명
- 사용한 라이브러리와 이유
- 결과 이미지(frontend-컴포넌트 사진, backend-로그)
- 다음 작업 내용 공유
- ...
-->

<!-- ## 📖 리뷰 가이드

### 📝 추가 설명
```
코드 설명
```
- .

### 🎨 결과

- .

### ➡️ 다음 작업

- . -->
