### PR TITLE
feat: 중복로그인 막기

### DIFF
--- a/requirements/backend/src/app.gateway.ts
+++ b/requirements/backend/src/app.gateway.ts
@@ -29,12 +29,9 @@ export class AppGateway {
     await this.validateUser(client);
     if (client.data.uid === undefined) return;
     client.join(`dm${client.data.uid}`);
-    // FIXME 테스트용.
-    // if (client.data.uid === 99857) {
-    //   client.join(`channel7`);
-    //   console.log(`socketInit: ${client.data.uid} join channel7`);
-    // }
-    console.log(`socketInit: ${client.data.uid} join dm${client.data.uid}`);
+    console.log(
+      `socketInit: ${client.data.uid} join dm${client.data.uid} (${client.id})`,
+    );
     await this.dmGateway.updateUser(client.data.uid);
   }
 
@@ -51,7 +48,7 @@ export class AppGateway {
     const user = await this.dmService.validateUser(token);
     const alreadyExist = this.sockets.has(user.uid);
 
-    if (alreadyExist) client.emit('already-exist', 'hey'); // FIXME 프론트와 얘기 해보자.
+    client.emit('login/dupCheck', !alreadyExist);
     if (!user || alreadyExist) {
       client.disconnect();
       return;
@@ -66,8 +63,8 @@ export class AppGateway {
     let token = client.handshake.headers.token;
     if (token === undefined) token = client.handshake.auth.token;
     if (!isString(token)) token = token[0];
-    //////////////////////////////////////////////////////////////////
-    // const { token } = client.handshake.auth; // 실제 사용
     return token;
+    //////////////////////////////////////////////////////////////////
+    // return client.handshake.auth.token; // 실제 사용
   }
 }


### PR DESCRIPTION
<!--
[PART1]
작업 내용 요약 정리
- 작업을 진행한 이유
- 리뷰 순서 (코드리뷰할 추천 순서)
- 연결된 이슈
-->

## 📍 개요
`client.emit('login/dupCheck', true | false);`
- 중복아니면 true
- 중복이면 false
- GGGLL에 로그인 한 상태로 postman 추가했을 때 바로 disconnect 되는 것 확인 완료
- close #155 
<!-- 만약 이슈도 PR과 동시에 종료시키려면 앞에 close를 명시[참고](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->

<!--
[PART2] // 필요할 때 주석을 지워서 사용하세요.
리뷰어를 위한 가이드제공 (선택사항)
- 일부 코드에 대한 자세한 설명
- 사용한 라이브러리와 이유
- 결과 이미지(frontend-컴포넌트 사진, backend-로그)
- 다음 작업 내용 공유
- ...
-->

<!-- ## 📖 리뷰 가이드

### 📝 추가 설명
```
코드 설명
```
- .

### 🎨 결과

- .

### ➡️ 다음 작업

- . -->
