### PR TITLE
Fix/165/static serve module error

### DIFF
--- a/requirements/backend/src/app.module.ts
+++ b/requirements/backend/src/app.module.ts
@@ -53,6 +53,7 @@ const dbOptions: TypeOrmModuleOptions = {
     LoginModule,
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '..', 'public'),
+      renderPath: 'img',
     }),
     TypeOrmModule.forRoot(dbOptions),
     DatabaseModule,


### PR DESCRIPTION
<!--
[PART1]
작업 내용 요약 정리
- 작업을 진행한 이유
- 리뷰 순서 (코드리뷰할 추천 순서)
- 연결된 이슈
-->

## 📍 개요

static serve 모듈 설정을 바꿔주니까
이미지 없을 때, index.html으로 자동 요청 안가고 404 not found 잘 뜨네요.

- #165 
<!-- 만약 이슈도 PR과 동시에 종료시키려면 앞에 close를 명시[참고](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->

<!--
[PART2] // 필요할 때 주석을 지워서 사용하세요.
리뷰어를 위한 가이드제공 (선택사항)
- 일부 코드에 대한 자세한 설명
- 사용한 라이브러리와 이유
- 결과 이미지(frontend-컴포넌트 사진, backend-로그)
- 다음 작업 내용 공유
- ...
-->

<!-- ## 📖 리뷰 가이드

### 📝 추가 설명
```
코드 설명
```
- .

### 🎨 결과

- .

### ➡️ 다음 작업

- . -->
