### PR TITLE
Feat/207/chat

### DIFF
--- a/requirements/backend/src/chat/chat.room.list.service.ts
+++ b/requirements/backend/src/chat/chat.room.list.service.ts
@@ -16,6 +16,7 @@ export class ChatRoomType {
 export interface DmRoomType {
   roomId: string;
   userId: number;
+  imgUri: string;
   userDisplayName: string;
 }
 
@@ -56,7 +57,7 @@ export class ChatRoomListService {
     const channels = await this.database.listUserDmChannel(uid);
     const roomList: DmRoomType[] = [];
     for (const uic of channels) {
-      const chatRoom = this.makeDmRoomType(uic.channel);
+      const chatRoom = await this.makeDmRoomType(uic.channel);
       roomList.push(chatRoom);
     }
     return roomList;
@@ -99,10 +100,11 @@ export class ChatRoomListService {
     };
   }
 
-  private makeDmRoomType(channel: ChannelEntity): DmRoomType {
+  private async makeDmRoomType(channel: ChannelEntity): Promise<DmRoomType> {
     return {
       roomId: 'channel' + channel.chid,
       userId: channel.chOwner.uid,
+      imgUri: (await this.database.findOneUser(channel.chOwner.uid)).imgUri,
       userDisplayName: channel.chOwner.displayName,
     };
   }

--- a/requirements/frontend/src/atoms/currChatState.ts
+++ b/requirements/frontend/src/atoms/currChatState.ts
@@ -1,8 +1,10 @@
 import { atom } from 'recoil';
+import { ChatUserType } from './chatUserType';
 
 export interface ChatLogType {
   index: number;
   uid: number;
+  user: ChatUserType | undefined;
   msg: string;
 }
 

--- a/requirements/frontend/src/pages/room/DmRoom.tsx
+++ b/requirements/frontend/src/pages/room/DmRoom.tsx
@@ -32,16 +32,6 @@ export function DmRoom() {
             'GET',
             `dm/log?target_uid=${currDmRoom?.userId}`,
           );
-
-        setCurrDmRoom((curr) => {
-          return {
-            userDisplayName: target.displayName,
-            imgUri: target.imgUri,
-            userId: target.uid,
-            roomId: curr?.roomId || 'error',
-            mode: curr?.mode || RoomModeType.DM,
-          };
-        });
         setDmLog(logs);
       } catch {
         throw new Error();
@@ -68,6 +58,7 @@ export function DmRoom() {
         return;
       }
 
+      setDmLog([]);
       setCurrDmRoom(null);
       setRefreshChannelList(true);
     };

--- a/requirements/frontend/src/pages/room/RoomSocket.tsx
+++ b/requirements/frontend/src/pages/room/RoomSocket.tsx
@@ -22,7 +22,7 @@ import { sortUserByName } from '../../utils/sortUserByName';
 
 export function RoomSocket({ children }: { children: React.ReactNode }) {
   const userProfile = useRecoilValue(userProfileState);
-  const setCurrUserList = useSetRecoilState(currUserListState);
+  const [currUserList, setCurrUserList] = useRecoilState(currUserListState);
   const [currMuteList, setCurrMuteList] = useRecoilState(currMuteListState);
   const setCurrBanList = useSetRecoilState(currBanListState);
   const [currRoom, setCurrRoom] = useRecoilState(currRoomState);
@@ -91,7 +91,12 @@ export function RoomSocket({ children }: { children: React.ReactNode }) {
       ) {
         setCurrChatState((curr) => [
           ...curr,
-          { uid: myUid, msg, index: curr.length },
+          {
+            index: curr.length,
+            uid: myUid,
+            user: currUserList.find((user) => user.uid === myUid),
+            msg: msg,
+          },
         ]);
       }
     });

--- a/requirements/frontend/src/pages/room/chat/Chat.tsx
+++ b/requirements/frontend/src/pages/room/chat/Chat.tsx
@@ -26,7 +26,7 @@ function LeftChat({
             <img src={user.imgUri} className={styles.chat__img} />
           )}
           {user === undefined ? (
-            'unknown'
+            'UNKNOWN'
           ) : (
             <div className={styles.chat__name}>{user.displayName}</div>
           )}
@@ -82,7 +82,7 @@ export function Chat() {
         ) : (
           <LeftChat
             chat={chat}
-            user={currUserList.find((user) => user.uid === chat.uid)}
+            user={chat.user}
             lastId={tempId}
             key={chat.index}
           />

--- a/requirements/frontend/src/pages/room/chat/DmChat.tsx
+++ b/requirements/frontend/src/pages/room/chat/DmChat.tsx
@@ -76,17 +76,17 @@ export function DmChat() {
     });
   }, [currRoom, setIsRefresh]);
 
-  // React.useEffect(() => {
-  //   if (scrollRef.current === null) return;
-  //   if (isRefresh === false) return;
+  React.useEffect(() => {
+    if (scrollRef.current === null) return;
+    if (isRefresh === false) return;
 
-  //   scrollRef.current.scrollIntoView({
-  //     behavior: 'smooth',
-  //     block: 'end',
-  //   });
+    scrollRef.current.scrollIntoView({
+      behavior: 'smooth',
+      block: 'end',
+    });
 
-  //   setIsRefresh(false);
-  // }, [scrollRef, dmLog, isRefresh, setIsRefresh]);
+    setIsRefresh(false);
+  }, [scrollRef, dmLog, isRefresh, setIsRefresh]);
 
   let lastId: number | undefined;
   let tempId: number | undefined;


### PR DESCRIPTION
<!--
[PART1]
작업 내용 요약 정리
- 작업을 진행한 이유
- 리뷰 순서 (코드리뷰할 추천 순서)
- 연결된 이슈
-->

## 📍 개요

- 채팅 중 한명이 나가면 다른 한명도 로비로 이동되는 문제
- - 채팅 내역이 채팅 유저 상태를 구독하지 않게 변경
- DM 방을 왔다갔다 할 때 자동으로 나가지는 문제
- - DM 방을 나갈 때 Log 초기화되게 변경
- DM 방에서 이미지가 제대로 안 뜨는 문제
- - backend에서 DmList에 imgUri도 같이 보내주게 변경
- close #207 
<!-- 만약 이슈도 PR과 동시에 종료시키려면 앞에 close를 명시[참고](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->

<!--
[PART2] // 필요할 때 주석을 지워서 사용하세요.
리뷰어를 위한 가이드제공 (선택사항)
- 일부 코드에 대한 자세한 설명
- 사용한 라이브러리와 이유
- 결과 이미지(frontend-컴포넌트 사진, backend-로그)
- 다음 작업 내용 공유
- ...
-->

<!-- ## 📖 리뷰 가이드

### 📝 추가 설명
```
코드 설명
```
- .

### 🎨 결과

- .

### ➡️ 다음 작업

- . -->
