### PR TITLE
Fix/210/chat bug

### DIFF
--- a/requirements/backend/src/chat/chat.gateway.ts
+++ b/requirements/backend/src/chat/chat.gateway.ts
@@ -147,7 +147,7 @@ export class ChatGateway {
       client.data.uid,
       payload,
     );
-    const ret = await this.chatRoomListService.makeChatRoomType(updateChannel);
+    const ret = await this.chatRoomListService.getCreatedRoom(updateChannel);
     this.server.to(`channel${payload.chid}`).emit('chat/updateChannel', ret);
   }
 

--- a/requirements/backend/src/chat/chat.room.list.service.ts
+++ b/requirements/backend/src/chat/chat.room.list.service.ts
@@ -89,7 +89,9 @@ export class ChatRoomListService {
     return await this.makeChatRoomType(channel);
   }
 
-  async makeChatRoomType(channel: ChannelEntity) {
+  private async makeChatRoomType(
+    channel: ChannelEntity,
+  ): Promise<ChatRoomType> {
     return {
       ownerId: channel.chOwner.uid,
       ownerDisplayName: channel.chOwner.displayName,

--- a/requirements/backend/src/database/db.channel/db.channel.service.ts
+++ b/requirements/backend/src/database/db.channel/db.channel.service.ts
@@ -73,7 +73,7 @@ export class DbChannelService {
     const channel = await this.findOne(body.chid);
     channel.chName = body.chName;
     channel.mode = body.mode;
-    if (channel.password !== '') {
+    if (body.password !== '') {
       channel.password = await this.encryptedPassword(body.password);
     }
     try {

--- a/requirements/backend/src/database/db.channel/db.channel.service.ts
+++ b/requirements/backend/src/database/db.channel/db.channel.service.ts
@@ -39,6 +39,9 @@ export class DbChannelService {
 
   async findOne(chid: number) {
     return await this.channelRepo.findOne({
+      relations: {
+        chOwner: true,
+      },
       where: { chid },
     });
   }

--- a/requirements/frontend/src/pages/room/RoomSocket.tsx
+++ b/requirements/frontend/src/pages/room/RoomSocket.tsx
@@ -157,7 +157,7 @@ export function RoomSocket({ children }: { children: React.ReactNode }) {
     });
 
     return () => {
-      socket.emit('leave', { uid: userProfile.uid });
+      // socket.emit('leave', { uid: userProfile.uid });
 
       socket.off('chat/addUserInChannel');
       socket.off('deleteUserInChannel');

--- a/requirements/frontend/src/pages/room/chat/ChatMain.tsx
+++ b/requirements/frontend/src/pages/room/chat/ChatMain.tsx
@@ -81,10 +81,6 @@ export function ChatMain() {
     }
   }, [isRefresh, currRoom]);
 
-  useInterval(() => {
-    setIsRefresh(true);
-  }, 3000);
-
   return currRoom === null ? null : (
     <>
       <div className={pagestyles.page}>


### PR DESCRIPTION
<!--
[PART1]
작업 내용 요약 정리
- 작업을 진행한 이유
- 리뷰 순서 (코드리뷰할 추천 순서)
- 연결된 이슈
-->

## 📍 개요

- 수정했삼
- close #210 
<!-- 만약 이슈도 PR과 동시에 종료시키려면 앞에 close를 명시[참고](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->

<!--
[PART2] // 필요할 때 주석을 지워서 사용하세요.
리뷰어를 위한 가이드제공 (선택사항)
- 일부 코드에 대한 자세한 설명
- 사용한 라이브러리와 이유
- 결과 이미지(frontend-컴포넌트 사진, backend-로그)
- 다음 작업 내용 공유
- ...
-->


### 📝 추가 설명
```
requirements/backend/src/database/db.channel/db.channel.service.ts
async findOne(chid: number) {
    return await this.channelRepo.findOne({
+      relations: {
+        chOwner: true,
+      },
      where: { chid },
    });
  }
```
- findOne을 통해 ChatRoomType을 반환받을 때 chOwner가 undefined인 상태로 오는 문제 때문에 에러가 발생해 수정했습니다. 
```
requirements/backend/src/database/db.channel/db.channel.service.ts
+ if (body.password !== '') {
      channel.password = await this.encryptedPassword(body.password);
    }
```
- 업데이트할 비밀번호로 판단해야 하는데 기존의 비밀번호로 판단해, Public Room을 Password Room으로 바꿀 때  비밀번호 갱신이 안 되는 문제를 수정했습니다.
```
-  useInterval(() => {
-   setIsRefresh(true);
-  }, 3000);
```
- 채팅방 정보 갱신이 잘 되어서 필요가 없어져 삭제합니다.
### 🎨 결과

- 굳

### ➡️ 다음 작업

- 몰룸
