### PR TITLE
dm 메세지 관리

### DIFF
--- a/requirements/backend/src/dm/dm.gateway.ts
+++ b/requirements/backend/src/dm/dm.gateway.ts
@@ -43,11 +43,6 @@ export class DmGateway {
 
   @SubscribeMessage('dm/msg')
   async handleMsg(client: Socket, payload: DmChatDto) {
-    await client.join(`dm${payload.targetUid}`);
-    this.server
-      .to(`dm${payload.targetUid}`)
-      .emit('dm/msg', payload.targetUid, payload.msg);
-    await client.leave(`dm${payload.targetUid}`);
     await this.dmService.addDmLog(
       client.data.uid,
       payload.targetUid,
@@ -55,6 +50,12 @@ export class DmGateway {
     );
     await this.dmService.addDmRoom(client.data.uid, payload.targetUid);
     await this.dmService.addDmRoom(payload.targetUid, client.data.uid);
+
+    await client.join(`dm${payload.targetUid}`);
+    this.server
+      .to(`dm${payload.targetUid}`)
+      .emit('dm/msg', payload.targetUid, payload.msg);
+    await client.leave(`dm${payload.targetUid}`);
   }
 
   @SubscribeMessage('dm/deleteUserInChannel')


### PR DESCRIPTION
- #208

<!--
[PART1]
작업 내용 요약 정리
- 작업을 진행한 이유
- 리뷰 순서 (코드리뷰할 추천 순서)
- 연결된 이슈
-->

## 📍 개요
- dm 메세지 저장 개수 제한 (기본: 100)
- 소켓 이벤트에서 데이터베이스 로직을 먼저 진행하고 emit
- dm log 가져오는 함수에 index 기준 정렬 추가
- close #208 
<!-- 만약 이슈도 PR과 동시에 종료시키려면 앞에 close를 명시[참고](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->

<!--
[PART2] // 필요할 때 주석을 지워서 사용하세요.
리뷰어를 위한 가이드제공 (선택사항)
- 일부 코드에 대한 자세한 설명
- 사용한 라이브러리와 이유
- 결과 이미지(frontend-컴포넌트 사진, backend-로그)
- 다음 작업 내용 공유
- ...
-->

<!-- ## 📖 리뷰 가이드

### 📝 추가 설명
```
코드 설명
```
- .

### 🎨 결과

- .

### ➡️ 다음 작업

- . -->
